### PR TITLE
Create two unified fetch api wrappers functions

### DIFF
--- a/src/lib/functions/clientFetchAPI.ts
+++ b/src/lib/functions/clientFetchAPI.ts
@@ -1,0 +1,21 @@
+type ClientFetchAPIOption = {
+    path: string;
+    method?: string;
+    body?: any;
+    successStatusCode?: number
+}
+
+export default async function clientFetchAPI<DataT>(options: ClientFetchAPIOption) {
+    const response = await fetch(options.path, {
+        method: options.method || "GET",
+        body: options.body && JSON.stringify(options.body)
+    })
+
+    const res = await response.json();
+
+    if (response.status === (options.successStatusCode || 200)) {
+        return res.result as DataT
+    } else {
+        throw (res.error || "Unexpected internal server error !")
+    }
+};

--- a/src/lib/functions/serverFetchAPI.ts
+++ b/src/lib/functions/serverFetchAPI.ts
@@ -1,0 +1,22 @@
+import { SERVER_HOST } from "$env/static/private";
+import type { Cookies } from "@sveltejs/kit";
+
+type ServerFetchAPIOptions = {
+    path: string;
+    method?: string;
+    body?: RequestInit["body"];
+    headers?: Record<string, string>;
+    cookies: Cookies;
+}
+
+export default async function serverFetchAPI(options: ServerFetchAPIOptions) {
+    const jwt = options.cookies.get("Mecha_Agent_JWT");
+    return await fetch(`${SERVER_HOST}${options.path}`, {
+        headers: {
+            Authorization: `Bearer ${jwt}`,
+            ...options.headers
+        },
+        method: options.method,
+        body: options.body,
+    });
+};


### PR DESCRIPTION
Create `serverFetchAPI` function which handles sending 
authenticated requests to the server from a proxy layer.

Create `clientFetchAPI` function which handles sending
the the requests from the client side to the proxy layer
which handles forwarding the requests to the server
with Authorization credentials.