### PR TITLE
Create the API proxies that handle requests to `/api/agents` & `/api/media` endponits 

### DIFF
--- a/src/routes/api/agents/+server.ts
+++ b/src/routes/api/agents/+server.ts
@@ -1,0 +1,40 @@
+import serverFetchAPI from "$lib/functions/serverFetchAPI.js";
+
+export async function GET({ cookies }) {
+    const response = await serverFetchAPI({ path: "/api/agents", cookies })
+
+    return new Response(response.body, { status: response.status });
+}
+
+export async function POST({ request, cookies, url }) {
+    const formData = await request.formData();
+    const avatarFile = formData.get("avatar") as File | null;
+
+    if (formData.get("responseSyntax") === "none") {
+        formData.delete("responseSyntax")
+    }
+
+    if (avatarFile && !avatarFile.name && !avatarFile.size) {
+        formData.delete("avatar")
+    }
+
+    const response = await serverFetchAPI({
+        method: "POST",
+        path: "/api/agents",
+        body: formData,
+        cookies
+    })
+
+    if (response.status === 201) {
+        return new Response(null, {
+            status: 302,
+            headers: new Headers({ Location: '/agents' })
+        });
+    } else {
+        const redirectUrl = new URL(url.origin);
+        const res = await response.json()
+        redirectUrl.searchParams.set("error", res.error || "an error happened while creating the agent");
+        return Response.redirect(redirectUrl);
+    }
+}
+

--- a/src/routes/api/agents/[agentId]/+server.ts
+++ b/src/routes/api/agents/[agentId]/+server.ts
@@ -1,0 +1,38 @@
+import serverFetchAPI from '$lib/functions/serverFetchAPI';
+
+export async function GET({ cookies, url }) {
+    const response = await serverFetchAPI({ path: url.pathname, cookies })
+    return new Response(response.body, { status: response.status });
+}
+
+export async function DELETE({ cookies, url }) {
+    const response = await serverFetchAPI({
+        method: "DELETE",
+        path: url.pathname,
+        cookies
+    })
+
+    return new Response(response.body, { status: response.status });
+}
+
+export async function PATCH({ request, cookies, url }) {
+    const formData = await request.formData();
+    const avatarFile = formData.get("avatar") as File | null;
+
+    if (formData.get("responseSyntax") === "none") {
+        formData.delete("responseSyntax")
+    }
+
+    if (avatarFile && !avatarFile.name && !avatarFile.size) {
+        formData.delete("avatar")
+    }
+
+    const response = await serverFetchAPI({
+        method: "PATCH",
+        path: url.pathname,
+        body: formData,
+        cookies
+    })
+
+    return new Response(response.body, { status: response.status });
+}

--- a/src/routes/api/media/[scope]/[mediaName]/+server.ts
+++ b/src/routes/api/media/[scope]/[mediaName]/+server.ts
@@ -1,0 +1,10 @@
+import serverFetchAPI from "$lib/functions/serverFetchAPI.js";
+
+export async function GET({ cookies, url }) {
+    const response = await serverFetchAPI({ cookies, path: url.pathname })
+
+    return new Response(response.body, {
+        headers: { "Content-Type": response.headers.get("Content-Type") as string },
+        status: response.status
+    });
+}


### PR DESCRIPTION
Inside `+server.ts` files that only run in the server side, Create the API proxies that handle communicating the actual 
back-end server that serves the web app.

The proxies receive the requests from the client (browser) and create a new authenticated request to the back-end server
and then after receiving responses from the back-end server they forward the responses back to the client.

Why?
To hide the actual back-end server from the client site for security purpose.